### PR TITLE
calendar point change : to DSL_public

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -1,5 +1,5 @@
 ---
 title: Data science lab / calendar
 layout: redirect
-rurl: https://calendar.google.com/calendar/u/0/embed?src=7b5c9848a297bf9814e2d51fed9aabb92079751eb75f3d949b0bd947244e9607@group.calendar.google.com&ctz=Asia/Seoul
+rurl: https://calendar.google.com/calendar/u/0/embed?src=ZWI2MzQ1ODA2ODQ5YTg0MTA5ZTcyMWZiNjg2YjZjMmRjYTRlM2Y3ODIzYzAyZmIxNzdmMWZlNjljNGI0NWJlYUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
 ---


### PR DESCRIPTION
메인페이지 우측하단 로고 링크를 수정하였습니다. 

원래 캘린더공유를 맴버로만 제한하여 일반 링커로는 사용 불가능해
전체공유로 변경하고 해당 포인트를 사용하였습니다.